### PR TITLE
Change behavior for handling subnets, availability zones, fixed some typos, and bumped nodejs version

### DIFF
--- a/aws/challenges/1_challenge_template/variables.tf
+++ b/aws/challenges/1_challenge_template/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Backwards/variables.tf
+++ b/aws/challenges/Backwards/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Bastion/bastion.tf
+++ b/aws/challenges/Bastion/bastion.tf
@@ -1,11 +1,3 @@
-data "aws_subnets" "first" {
-    filter {
-        name = "tag:Name"
-        values = ["cloudfox Operational Subnet 1"]
-    }
-}
-
-
 data "aws_ami" "bastion" {
   most_recent = true
 
@@ -52,7 +44,7 @@ output "intra-sg-access-id" {
 resource "aws_instance" "bastion" {
   ami           = data.aws_ami.bastion.id
   instance_type = "t3a.nano"
-  subnet_id = data.aws_subnets.first.ids 
+  subnet_id = var.subnets[0] 
   iam_instance_profile = aws_iam_instance_profile.bastion.name
   associate_public_ip_address = true
   vpc_security_group_ids = [ aws_security_group.intra-sg-access.id ]
@@ -115,14 +107,14 @@ resource "aws_iam_role_policy_attachment" "bastion-deny" {
 
 
 resource "aws_iam_instance_profile" "bastion" {
-  name = "bastion"
+  name = "bastion-cloudfoxable"
   role = aws_iam_role.bastion.name
 }
 
 
 // create a policy that allows the bastion to list and download the contents of an S3 bucket called cloudfoxable-bastion-RANDOMSTRING
 resource "aws_iam_policy" "bastion-s3" {
-  name = "bastion-s3"
+  name = "bastion-cloudfoxable-s3"
   description = "Allows the bastion to list and download the contents of the S3 bucket with flag"
   policy = jsonencode({
     Version = "2012-10-17"
@@ -185,7 +177,7 @@ resource "aws_s3_bucket_public_access_block" "cloudfoxable-bastion-public-access
 resource "aws_s3_object" "cloudfoxable-bastion-object" {
   bucket = aws_s3_bucket.cloudfoxable-bastion.id
   key    = "flag.txt"
-  source = "./challenges/bastion/data/flag.txt"
+  source = "./challenges/Bastion/data/flag.txt"
 }
 
 // create a policy that will allow the ctf starting user to ssm:startsession to the bastion

--- a/aws/challenges/Bastion/bastion.tf
+++ b/aws/challenges/Bastion/bastion.tf
@@ -1,3 +1,10 @@
+data "aws_subnets" "first" {
+    filter {
+        name = "tag:Name"
+        values = ["cloudfox Operational Subnet 1"]
+    }
+}
+
 
 data "aws_ami" "bastion" {
   most_recent = true
@@ -45,7 +52,7 @@ output "intra-sg-access-id" {
 resource "aws_instance" "bastion" {
   ami           = data.aws_ami.bastion.id
   instance_type = "t3a.nano"
-  subnet_id = var.subnet1_id
+  subnet_id = data.aws_subnets.first.ids 
   iam_instance_profile = aws_iam_instance_profile.bastion.name
   associate_public_ip_address = true
   vpc_security_group_ids = [ aws_security_group.intra-sg-access.id ]

--- a/aws/challenges/Bastion/variables.tf
+++ b/aws/challenges/Bastion/variables.tf
@@ -83,3 +83,9 @@ variable "ctf_starting_user_name" {
   type        = string
   default     = ""
 }
+
+variable "subnets" {
+    description = "List of vpc subnets"
+    type = list
+    default = []
+}

--- a/aws/challenges/Bastion/variables.tf
+++ b/aws/challenges/Bastion/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Double Tap/variables.tf
+++ b/aws/challenges/Double Tap/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Furls 1/variables.tf
+++ b/aws/challenges/Furls 1/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Furls 2/variables.tf
+++ b/aws/challenges/Furls 2/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/It's a secret/variables.tf
+++ b/aws/challenges/It's a secret/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/It's another secret/variables.tf
+++ b/aws/challenges/It's another secret/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Middle/variables.tf
+++ b/aws/challenges/Middle/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Needles/variables.tf
+++ b/aws/challenges/Needles/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Pain/variables.tf
+++ b/aws/challenges/Pain/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Root/variables.tf
+++ b/aws/challenges/Root/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Search 1/variables.tf
+++ b/aws/challenges/Search 1/variables.tf
@@ -35,21 +35,6 @@ variable "AWS_REGION" {
 }
 
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/The Repot Depot/variables.tf
+++ b/aws/challenges/The Repot Depot/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/The topic is execution/the-topic-is-execution.tf
+++ b/aws/challenges/The topic is execution/the-topic-is-execution.tf
@@ -129,7 +129,7 @@ resource "aws_lambda_function" "executioner" {
   role             = aws_iam_role.executioner-role.arn
   handler          = "index.handler"
   source_code_hash = data.archive_file.executioner_zip.output_base64sha256
-  runtime          = "nodejs14.x"
+  runtime          = "nodejs16.x"
 }
 
 

--- a/aws/challenges/The topic is execution/the-topic-is-execution.tf
+++ b/aws/challenges/The topic is execution/the-topic-is-execution.tf
@@ -129,7 +129,7 @@ resource "aws_lambda_function" "executioner" {
   role             = aws_iam_role.executioner-role.arn
   handler          = "index.handler"
   source_code_hash = data.archive_file.executioner_zip.output_base64sha256
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs18.x"
 }
 
 

--- a/aws/challenges/The topic is execution/variables.tf
+++ b/aws/challenges/The topic is execution/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/The topic is exposure/variables.tf
+++ b/aws/challenges/The topic is exposure/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Trust me/variables.tf
+++ b/aws/challenges/Trust me/variables.tf
@@ -34,21 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Variable/rds.tf
+++ b/aws/challenges/Variable/rds.tf
@@ -1,14 +1,7 @@
-data "aws_subnets" "cloudfox" {
-  filter {
-    name = "vpc-id"
-    values = [var.vpc_id]
-  }
-}
-
 resource "aws_db_subnet_group" "default" {
   name        = "rds-subnet-group"
   description = "Terraform example RDS subnet group"
-  subnet_ids  = data.aws_subnets.cloudfox.ids 
+  subnet_ids  = var.subnets 
 }
 
 
@@ -31,12 +24,12 @@ resource "aws_db_instance" "default" {
 
 data "archive_file" "lambda-rds_zip" {
     type          = "zip"
-    source_dir   = "challenges/variable/data/lambda-src"
-    output_path   = "challenges/variable/data/lambda_function.zip"
+    source_dir   = "challenges/Variable/data/lambda-src"
+    output_path   = "challenges/Variable/data/lambda_function.zip"
 }
 
 resource "aws_lambda_function" "rds_sql_executor" {
-  filename         = "challenges/variable/data/lambda_function.zip"
+  filename         = "challenges/Variable/data/lambda_function.zip"
   function_name    = "rds-sql-executor"
   runtime          = "python3.9"
   handler          = "lambda_function.lambda_handler"
@@ -45,7 +38,7 @@ resource "aws_lambda_function" "rds_sql_executor" {
   timeout          = 60
 
   vpc_config {
-    subnet_ids         = data.aws_subnets.cloudfox.ids 
+    subnet_ids         = var.subnets 
     security_group_ids = [var.intra-sg-access-id]
   }
 

--- a/aws/challenges/Variable/rds.tf
+++ b/aws/challenges/Variable/rds.tf
@@ -1,7 +1,14 @@
+data "aws_subnets" "cloudfox" {
+  filter {
+    name = "vpc-id"
+    values = [var.vpc_id]
+  }
+}
+
 resource "aws_db_subnet_group" "default" {
   name        = "rds-subnet-group"
   description = "Terraform example RDS subnet group"
-  subnet_ids  = [var.subnet1_id, var.subnet2_id, var.subnet3_id]
+  subnet_ids  = data.aws_subnets.cloudfox.ids 
 }
 
 
@@ -38,7 +45,7 @@ resource "aws_lambda_function" "rds_sql_executor" {
   timeout          = 60
 
   vpc_config {
-    subnet_ids         = [var.subnet1_id, var.subnet2_id]
+    subnet_ids         = data.aws_subnets.cloudfox.ids 
     security_group_ids = [var.intra-sg-access-id]
   }
 

--- a/aws/challenges/Variable/variables.tf
+++ b/aws/challenges/Variable/variables.tf
@@ -39,37 +39,6 @@ variable "vpc_id" {
   default = ""
 }
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Variable/variables.tf
+++ b/aws/challenges/Variable/variables.tf
@@ -90,6 +90,12 @@ variable "intra-sg-access-id" {
   default     = ""
 }
 
+variable "subnets" {
+  description = "List of vpc subnets"
+  type = list
+  default = []
+}
+
 resource "random_password" "rds-password" {
   length           = 31
   special          = true

--- a/aws/challenges/Wyatt/variables.tf
+++ b/aws/challenges/Wyatt/variables.tf
@@ -45,37 +45,6 @@ variable "vpc_cidr" {
 }
 
 
-variable "subnet1_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet2_id" {
-  type    = string
-  default = ""
-}
-
-variable "subnet3_id" {
-  type    = string
-  default = ""
-}
-
-
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 # Resources
 resource "random_password" "database-secret" {
   length           = 31

--- a/aws/challenges/Wyatt/variables.tf
+++ b/aws/challenges/Wyatt/variables.tf
@@ -44,6 +44,11 @@ variable "vpc_cidr" {
   default = ""
 }
 
+variable "subnets" {
+    type = list
+    default = []
+}
+
 
 # Resources
 resource "random_password" "database-secret" {

--- a/aws/challenges/Wyatt/wyatt.tf
+++ b/aws/challenges/Wyatt/wyatt.tf
@@ -1,10 +1,3 @@
-data "aws_subnets" "first" {
-    filter {
-        name = "tag:Name"
-        values = ["cloudfox Operational Subnet 1"]
-    }
-}
-
 data "aws_ami" "amazon_linux" {
   most_recent = true
   owners      = ["amazon"]
@@ -27,7 +20,7 @@ resource "aws_instance" "wyatt" {
   iam_instance_profile = aws_iam_instance_profile.wyatt.name
 
   instance_type = "t3a.nano"
-  subnet_id = data.aws_subnets.first.ids 
+  subnet_id = var.subnets[0] 
   user_data = <<-EOF
                 #!/bin/bash
                 yum update -y

--- a/aws/challenges/Wyatt/wyatt.tf
+++ b/aws/challenges/Wyatt/wyatt.tf
@@ -1,3 +1,10 @@
+data "aws_subnets" "first" {
+    filter {
+        name = "tag:Name"
+        values = ["cloudfox Operational Subnet 1"]
+    }
+}
+
 data "aws_ami" "amazon_linux" {
   most_recent = true
   owners      = ["amazon"]
@@ -20,7 +27,7 @@ resource "aws_instance" "wyatt" {
   iam_instance_profile = aws_iam_instance_profile.wyatt.name
 
   instance_type = "t3a.nano"
-  subnet_id = var.subnet1_id
+  subnet_id = data.aws_subnets.first.ids 
   user_data = <<-EOF
                 #!/bin/bash
                 yum update -y

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -230,6 +230,7 @@ module "challenge_middle" {
     vpc_id = module.enabled.vpc_id
     vpc_cidr = module.enabled.vpc_cidr
     AWS_REGION = var.AWS_REGION
+    subnets = output.enabled.subnet_ids
     }
 
 
@@ -249,7 +250,7 @@ module "challenge_bastion" {
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   vpc_id = module.enabled.vpc_id
   AWS_REGION = var.AWS_REGION    
-
+  subnets = module.enabled.subnet_ids 
 }
 
 module "challenge_variable" {
@@ -261,7 +262,7 @@ module "challenge_variable" {
   user_ip = local.user_ip
   intra-sg-access-id = module.challenge_bastion[0].intra-sg-access-id
   AWS_REGION = var.AWS_REGION    
-
+  subnets = module.enabled.subnet_ids
 }
 
 ##############################################

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -50,9 +50,6 @@ module "enabled" {
   aws_local_profile = var.aws_local_profile
   user_ip = local.user_ip
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 
@@ -71,9 +68,6 @@ module "challenge_its_a_secret" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 
@@ -87,9 +81,6 @@ module "challenge_its_another_secret" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 }
 
 module "challenge_backwards" {
@@ -102,9 +93,6 @@ module "challenge_backwards" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 }
 
 module "challenge_the_topic_is_execution" {
@@ -117,9 +105,6 @@ module "challenge_the_topic_is_execution" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 }
 
 module "challenge_root" {
@@ -133,9 +118,6 @@ module "challenge_root" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 }
 
 module "challenge_double_tap" {
@@ -148,9 +130,6 @@ module "challenge_double_tap" {
     ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
     ctf_starting_user_name = module.enabled.ctf_starting_user_name
     AWS_REGION = var.AWS_REGION
-    AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-    AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-    AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
   }
 
 module "challenge_needles" {
@@ -163,9 +142,6 @@ module "challenge_needles" {
     ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
     ctf_starting_user_name = module.enabled.ctf_starting_user_name
     AWS_REGION = var.AWS_REGION
-    AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-    AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-    AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
   }
 
   module "challenge_pain" {
@@ -178,9 +154,6 @@ module "challenge_needles" {
     ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
     ctf_starting_user_name = module.enabled.ctf_starting_user_name
     AWS_REGION = var.AWS_REGION
-    AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-    AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-    AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
   }
 
 ###################################################
@@ -197,9 +170,6 @@ module "challenge_search1and2" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 
@@ -211,9 +181,6 @@ module "challenge_furls1" {
   aws_local_profile = var.aws_local_profile
   user_ip = local.user_ip
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 }
 
 
@@ -227,9 +194,6 @@ module "challenge_furls2" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 }
 
 module "challenge_the_topic_is_exposure" {
@@ -240,9 +204,6 @@ module "challenge_the_topic_is_exposure" {
   aws_local_profile = var.aws_local_profile
   user_ip = local.user_ip
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 
@@ -256,9 +217,6 @@ module "challenge_middle" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   AWS_REGION = var.AWS_REGION
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 
@@ -271,13 +229,7 @@ module "challenge_middle" {
     user_ip = local.user_ip
     vpc_id = module.enabled.vpc_id
     vpc_cidr = module.enabled.vpc_cidr
-    subnet1_id = module.enabled.subnet1_id
-    subnet2_id = module.enabled.subnet2_id
-    subnet3_id = module.enabled.subnet3_id
     AWS_REGION = var.AWS_REGION
-    AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-    AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-    AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
     }
 
 
@@ -296,13 +248,7 @@ module "challenge_bastion" {
   ctf_starting_user_arn = module.enabled.ctf_starting_user_arn
   ctf_starting_user_name = module.enabled.ctf_starting_user_name
   vpc_id = module.enabled.vpc_id
-  subnet1_id = module.enabled.subnet1_id
-  subnet2_id = module.enabled.subnet2_id
-  subnet3_id = module.enabled.subnet3_id
   AWS_REGION = var.AWS_REGION    
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 
@@ -314,13 +260,7 @@ module "challenge_variable" {
   aws_local_profile = var.aws_local_profile
   user_ip = local.user_ip
   intra-sg-access-id = module.challenge_bastion[0].intra-sg-access-id
-  subnet1_id = module.enabled.subnet1_id
-  subnet2_id = module.enabled.subnet2_id
-  subnet3_id = module.enabled.subnet3_id
   AWS_REGION = var.AWS_REGION    
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 
@@ -338,9 +278,6 @@ module "challenge_trust_me" {
   user_ip = local.user_ip
   github_repo = var.github_repo
   AWS_REGION = var.AWS_REGION    
-  AWS_REGION_SUB_1 = var.AWS_REGION_SUB_1
-  AWS_REGION_SUB_2 = var.AWS_REGION_SUB_2
-  AWS_REGION_SUB_3 = var.AWS_REGION_SUB_3
 
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -230,7 +230,7 @@ module "challenge_middle" {
     vpc_id = module.enabled.vpc_id
     vpc_cidr = module.enabled.vpc_cidr
     AWS_REGION = var.AWS_REGION
-    subnets = output.enabled.subnet_ids
+    subnets = module.enabled.subnet_ids
     }
 
 

--- a/aws/modules/disabled/cloud9.tf
+++ b/aws/modules/disabled/cloud9.tf
@@ -1,3 +1,9 @@
+# data "aws_subnets" "first" {
+#     filter {
+#         name = "tag:Name"
+#         values = ["cloudfox Operational Subnet 1"]
+#     }
+# }
 
 # resource "aws_iam_role" "cloud9_role" {
 #   name               = "Cloud9InstanceRole"
@@ -25,7 +31,7 @@
 
 # resource "aws_cloud9_environment_ec2" "example" {
 #   instance_type     = "t2.micro" # or any other desired instance type
-#   subnet_id         = var.subnet1_id 
+#   subnet_id         = data.aws_subnets.first.ids 
 #   name              = "my-cloud9-env"
 #   owner_arn         = aws_iam_role.cloud9_role.arn
 #   automatic_stop_time_minutes = 30 # Automatically stop the environment after it's inactive for 30 minutes

--- a/aws/modules/disabled/cloud9.tf
+++ b/aws/modules/disabled/cloud9.tf
@@ -1,10 +1,3 @@
-# data "aws_subnets" "first" {
-#     filter {
-#         name = "tag:Name"
-#         values = ["cloudfox Operational Subnet 1"]
-#     }
-# }
-
 # resource "aws_iam_role" "cloud9_role" {
 #   name               = "Cloud9InstanceRole"
 #   assume_role_policy = <<EOF
@@ -31,7 +24,7 @@
 
 # resource "aws_cloud9_environment_ec2" "example" {
 #   instance_type     = "t2.micro" # or any other desired instance type
-#   subnet_id         = data.aws_subnets.first.ids 
+#   subnet_id         = var.subnets[0] 
 #   name              = "my-cloud9-env"
 #   owner_arn         = aws_iam_role.cloud9_role.arn
 #   automatic_stop_time_minutes = 30 # Automatically stop the environment after it's inactive for 30 minutes

--- a/aws/modules/disabled/docdb.tf
+++ b/aws/modules/disabled/docdb.tf
@@ -1,3 +1,5 @@
+data "aws_availability_zones" "available" {}
+
 # Create a security group
 resource "aws_security_group" "example_security_group" {
   vpc_id = aws_vpc.cloudfox.id
@@ -15,7 +17,7 @@ resource "aws_security_group" "example_security_group" {
 # Create a subnet group
 resource "aws_docdb_subnet_group" "example_subnet_group" {
   name       = "example-subnet-group"
-  subnet_ids = [aws_subnet.cloudfox-operational-1.id, aws_subnet.cloudfox-operational-2.id, aws_subnet.cloudfox-operational-3.id]
+  subnet_ids = aws_subnet.cloudfox-operational.*.id
 }
 
 
@@ -23,7 +25,7 @@ resource "aws_docdb_subnet_group" "example_subnet_group" {
 # Create a DocumentDB cluster
 resource "aws_docdb_cluster" "example_cluster" {
   cluster_identifier        = "example-cluster"
-  availability_zones        = [var.AWS_REGION_SUB_1, var.AWS_REGION_SUB_2, var.AWS_REGION_SUB_3]
+  availability_zones        = data.aws_availability_zones.available.names 
   master_username           = "cloudfoxable"
   master_password           = "password123"  # Replace with your own password
   vpc_security_group_ids    = [aws_security_group.example_security_group.id]

--- a/aws/modules/disabled/github-pat/variables.tf
+++ b/aws/modules/disabled/github-pat/variables.tf
@@ -34,20 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
 
 # Resources
 resource "random_password" "database-secret" {

--- a/aws/modules/enabled/variables.tf
+++ b/aws/modules/enabled/variables.tf
@@ -34,20 +34,6 @@ variable "AWS_REGION" {
   default = "us-west-2"
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
 
 # Resources
 resource "random_password" "database-secret" {

--- a/aws/modules/enabled/vpc.tf
+++ b/aws/modules/enabled/vpc.tf
@@ -56,6 +56,6 @@ output "vpc_cidr" {
 }
 
 // output subnet_id
-output "subnet_id" {
+output "subnet_ids" {
   value = aws_subnet.cloudfox-operational.*.id
 }

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -45,9 +45,6 @@ aws_local_profile = "default"
 
 # Uncomment the next lines to use a region other than us-west-2 for your lab
 # AWS_REGION = "us-east-1"
-# AWS_REGION_SUB_1 = "us-east-1a"
-# AWS_REGION_SUB_2 = "us-east-1b"
-# AWS_REGION_SUB_3 = "us-east-1c"
 
 
 ############################

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -29,21 +29,6 @@ variable "AWS_REGION" {
   default = "us-west-2" 
 }
 
-variable "AWS_REGION_SUB_1" {
-  type    = string
-  default = "us-west-2a"
-}
-
-variable "AWS_REGION_SUB_2" {
-  type    = string
-  default = "us-west-2b"
-}
-
-variable "AWS_REGION_SUB_3" {
-  type    = string
-  default = "us-west-2c"
-}
-
 variable "user_ip" {
   description = "The current user's IP address"
   type        = string


### PR DESCRIPTION
The way subnets and availability zones were handle were bothersome.  In AWS land there is not complete consistency across all regions.  For example in us-west-1 there are only AZ's A and C.   This broke the Terraform execute because in terraform.tfvars if you defined your region as us-west-1 the apply would fail due to the default sub-regions also being defined as us-west-2{a,b,c}.  This creates a poor user experience.  

While investigating and fixing this, I also subnets were being defined 1 at a time instead of altogether and then used as a list.  So I changed that behavior too.  When subnets are used in a challenge I pass that in now as a list and access using elements.  

I also found that in some disabled challenges such as Variable that depends on Bastion there was some typos so I fixed those as well.

My last finding for this PR is nodejs14 is deprecated and in some regions it is ok but in other regions (like us-west-1) the api returns a 400 so I bumped this to nodejs18.x.

