### PR TITLE
Fix typo for the challenge Backwards

### DIFF
--- a/aws/challenges/Backwards/challenge.yml
+++ b/aws/challenges/Backwards/challenge.yml
@@ -35,7 +35,7 @@ hints:
 - |-
   If your stuck, try running the permissions command in cloudfox and grepping for the word secret:
 
-  `cloudfox aws -p cloudfoxable aws permissions -v2 | grep -i secret`
+  `cloudfox aws -p cloudfoxable permissions -v2 | grep -i secret`
 
   Do you see user or role that has the permission to get all secretsmanager secret values, or even just the value of the secret we want?
 - |-

--- a/aws/challenges/Backwards/challenge.yml
+++ b/aws/challenges/Backwards/challenge.yml
@@ -35,7 +35,7 @@ hints:
 - |-
   If your stuck, try running the permissions command in cloudfox and grepping for the word secret:
 
-  `cloudfox aws -p cloudfoxable permissions -v2 | grep -i secret`
+  `cloudfox aws -p cloudfoxable aws permissions -v2 | grep -i secret`
 
   Do you see user or role that has the permission to get all secretsmanager secret values, or even just the value of the secret we want?
 - |-
@@ -49,7 +49,7 @@ hints:
 
   Try:
 
-  `cloudfox -p cloudfoxable role-trusts -v2`
+  `cloudfox -p cloudfoxable aws role-trusts -v2`
 
   Find our target role, and see who it trusts?
 - |-


### PR DESCRIPTION
This PR fixes the typo in the challenge [backwards](https://cloudfoxable.bishopfox.com/challenges#Backwards-9), where `aws` is missed in the commands given in hints section.

Fixes - #17 