### PR TITLE
Fixed bug in Bastion that was preventing ctf-starting-user from ssm

### DIFF
--- a/aws/challenges/Bastion/bastion.tf
+++ b/aws/challenges/Bastion/bastion.tf
@@ -197,6 +197,8 @@ resource "aws_iam_policy" "bastion-ssm" {
         Effect = "Allow"
         Resource = [
           aws_instance.bastion.arn,
+          "arn:aws:ssm:us-west-2:${var.account_id}:document/SSM-SessionManagerRunShell",
+          "arn:aws:ssm:us-west-2:${var.account_id}:session/ctf-starting-user-*",
         ]
       },
     ]


### PR DESCRIPTION
Not sure when or how this started, but anonymous discord user reported bug where `ctf-starting-user` couldn't ssm into the bastion ec2 with the applied `bastion-ssm` policy.  This updated fix seems to fix the issue. 
