### PR TITLE
Updating bastion module to properly set the AWS region variable

### DIFF
--- a/aws/challenges/Bastion/bastion.tf
+++ b/aws/challenges/Bastion/bastion.tf
@@ -197,8 +197,8 @@ resource "aws_iam_policy" "bastion-ssm" {
         Effect = "Allow"
         Resource = [
           aws_instance.bastion.arn,
-          "arn:aws:ssm:us-west-2:${var.account_id}:document/SSM-SessionManagerRunShell",
-          "arn:aws:ssm:us-west-2:${var.account_id}:session/ctf-starting-user-*",
+          "arn:aws:ssm:${var.AWS_REGION}:${var.account_id}:document/SSM-SessionManagerRunShell",
+          "arn:aws:ssm:${var.AWS_REGION}:${var.account_id}:session/ctf-starting-user-*",
         ]
       },
     ]


### PR DESCRIPTION
#### Card

Replacing the hardcoded `us-west-2` region with the terraform `var.region` variable. If the region the user uses is not the default one, permission issues may exist using the SSM service.  

