### PR TITLE
Update ifconfig.me call to ifconfig.me/ip 

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -33,7 +33,7 @@ data "aws_caller_identity" "current" {}
 
 
 data "http" "current_ip" {
-  url = "https://ifconfig.me"
+  url = "https://ifconfig.me/ip"
 }
 
 locals {


### PR DESCRIPTION
The ifconfig.me side now provides more info than just ip, and they moved the ip to a new endpoint. 

This fixes #27 and #29