### PR TITLE
Fixed white-rabbit config in main.tf (referenced segue)

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.50"
+      version = "~> 6.0"
     }
     
     http = {
@@ -170,7 +170,7 @@ module "challenge_needles" {
 
 module "challenge_white_rabbit" {
   source = "./challenges/white_rabbit"
-  count = var.segue_enabled ? 1 : 0
+  count = var.white_rabbit_enabled ? 1 : 0
   aws_assume_role_arn = (var.aws_assume_role_arn != "" ? var.aws_assume_role_arn : data.aws_caller_identity.current.arn) 
   account_id = data.aws_caller_identity.current.account_id
   aws_local_profile = var.aws_local_profile


### PR DESCRIPTION
White rabbit was checking to see if segue flag was enabled. 

I also bumped the terraform aws provider version to use the new 6.0 line. 